### PR TITLE
support for encrypted passwords

### DIFF
--- a/github-site-plugin/pom.xml
+++ b/github-site-plugin/pom.xml
@@ -209,7 +209,7 @@
 		<dependency>
 			<groupId>com.github.github</groupId>
 			<artifactId>github-maven-core</artifactId>
-			<version>0.4</version>
+			<version>0.5-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
+++ b/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
@@ -181,6 +182,13 @@ public class SiteMojo extends GitHubProjectMojo {
 	 * @required
 	 */
 	private MavenProject project;
+
+	/**
+	 * Session
+	 * 
+	 * @parameter expression="${session}
+	 */
+	private MavenSession session;
 
 	/**
 	 * Settings
@@ -339,7 +347,7 @@ public class SiteMojo extends GitHubProjectMojo {
 					Arrays.toString(paths)));
 
 		DataService service = new DataService(createClient(host, userName,
-				password, oauth2Token, server, settings));
+				password, oauth2Token, server, settings, session));
 
 		// Write blobs and build tree entries
 		List<TreeEntry> entries = new ArrayList<TreeEntry>(paths.length);


### PR DESCRIPTION
Added the Maven 3 API for retrieving the authentication credentials from the repository system, rather than manually getting them from the settings file, which will ensure that they are first decrypted.

With this in place, you could remove the Settings object and extra branch altogether - if you're not looking to maintain the behaviour of the API.

I haven't tested this change on the download mojo as I'm not using it, but I expect it works the same. Happy to revise as needed.
