### PR TITLE
used maven-plugin-tools-javadoc to reduce warning for javadoc

### DIFF
--- a/github-downloads-plugin/pom.xml
+++ b/github-downloads-plugin/pom.xml
@@ -67,6 +67,16 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<!-- avoiding javadoc warnings caused by Mojo annotations -->
+					<tagletArtifacts>
+						<tagletArtifact>
+							<groupId>org.apache.maven.plugin-tools</groupId>
+							<artifactId>maven-plugin-tools-javadoc</artifactId>
+							<version>2.9</version>
+						</tagletArtifact>
+					</tagletArtifacts>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/github-site-plugin/pom.xml
+++ b/github-site-plugin/pom.xml
@@ -67,6 +67,16 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<!-- avoiding javadoc warnings caused by Mojo annotations -->
+					<tagletArtifacts>
+						<tagletArtifact>
+							<groupId>org.apache.maven.plugin-tools</groupId>
+							<artifactId>maven-plugin-tools-javadoc</artifactId>
+							<version>2.9</version>
+						</tagletArtifact>
+					</tagletArtifacts>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Thanks for your product.
I created a simple update to reduce warning on build phase. This change remove a warning like this:

```
[WARNING] Javadoc Warnings
[WARNING] /Users/kengo/Documents/workspace/github/github-maven-plugins/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java:67: warning - @goal is an unknown tag.
```

I hope you like it.
