### PR TITLE
Make non-https protocols work in host parameter (for GH Enterprise)

### DIFF
--- a/github-core/src/main/java/com/github/maven/plugins/core/GitHubProjectMojo.java
+++ b/github-core/src/main/java/com/github/maven/plugins/core/GitHubProjectMojo.java
@@ -21,6 +21,12 @@
  */
 package com.github.maven.plugins.core;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.MessageFormat;
+import java.util.List;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -34,14 +40,6 @@ import org.sonatype.aether.RepositorySystemSession;
 import org.sonatype.aether.repository.Authentication;
 import org.sonatype.aether.repository.RemoteRepository;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.text.MessageFormat;
-import java.util.List;
-
-import static org.eclipse.egit.github.core.client.IGitHubConstants.PROTOCOL_HTTPS;
-import static org.eclipse.egit.github.core.client.IGitHubConstants.SUBDOMAIN_API;
 
 /**
  * Base GitHub Mojo class to be extended.
@@ -170,17 +168,16 @@ public abstract class GitHubProjectMojo extends AbstractMojo {
 	 * @return non-null client
 	 */
 	protected GitHubClient createClient(String hostname) throws MojoExecutionException{
-        // default to https, because of legacy
-        if (!hostname.contains("://"))
-            hostname = PROTOCOL_HTTPS + "://" + SUBDOMAIN_API + "." + hostname;
-        URL hostUrl;
-        try {
-            hostUrl = new URL(hostname);
-        } catch (MalformedURLException e) {
-            throw new MojoExecutionException("Could not parse host URL " + hostname);
-        }
-        return new GitHubClient(hostUrl.getHost(), hostUrl.getPort(), hostUrl.getProtocol());
-    }
+		// default to https, because of legacy
+		if (!hostname.contains("://"))
+			return new GitHubClient(hostname);
+		try {
+			URL hostUrl = new URL(hostname);
+			return new GitHubClient(hostUrl.getHost(), hostUrl.getPort(), hostUrl.getProtocol());
+		} catch (MalformedURLException e) {
+			throw new MojoExecutionException("Could not parse host URL " + hostname);
+		}
+	}
 
 	/**
 	 * Create client

--- a/github-core/src/test/java/com/github/maven/plugins/core/CustomHostnameTest.java
+++ b/github-core/src/test/java/com/github/maven/plugins/core/CustomHostnameTest.java
@@ -21,16 +21,18 @@
  */
 package com.github.maven.plugins.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.settings.Settings;
 import org.eclipse.egit.github.core.client.GitHubClient;
 import org.junit.Test;
-
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests using client with custom hostname


### PR DESCRIPTION
Creating a Git client for a non-https protocol fails. For instance, using this configuration (with github-site-plugin):

```
<configuration>
  <host>http://github.internal</host>
  <message>Building site for ${project.version}</message>
</configuration>
```

fails with the message:

```
[INFO] Error creating blob: http
```

This change makes https the default (like before), but supports http (and other protocols, but they should never really be used though..) as well.
