### PR TITLE
Reduce plugin dependencies.

### DIFF
--- a/github-core/pom.xml
+++ b/github-core/pom.xml
@@ -126,11 +126,13 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>3.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
 			<version>3.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.mylyn.github</groupId>

--- a/github-downloads-plugin/pom.xml
+++ b/github-downloads-plugin/pom.xml
@@ -200,11 +200,13 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>3.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
 			<version>3.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.mylyn.github</groupId>

--- a/github-site-plugin/pom.xml
+++ b/github-site-plugin/pom.xml
@@ -200,16 +200,13 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-site-plugin</artifactId>
-			<version>3.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
 			<version>3.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.mylyn.github</groupId>


### PR DESCRIPTION
- Removed maven-site-plugin
- Made maven dependencies provided

When running the site target a lot of dependencies from the maven site plugin are downloaded, even when they are not needed.
