### PR TITLE
Fix user-agent-required when updating download and site

### DIFF
--- a/github-core/pom.xml
+++ b/github-core/pom.xml
@@ -135,7 +135,7 @@
 		<dependency>
 			<groupId>org.eclipse.mylyn.github</groupId>
 			<artifactId>org.eclipse.egit.github.core</artifactId>
-			<version>2.0.1</version>
+			<version>2.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/github-downloads-plugin/pom.xml
+++ b/github-downloads-plugin/pom.xml
@@ -209,7 +209,7 @@
 		<dependency>
 			<groupId>org.eclipse.mylyn.github</groupId>
 			<artifactId>org.eclipse.egit.github.core</artifactId>
-			<version>2.0.1</version>
+			<version>2.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.github</groupId>

--- a/github-site-plugin/pom.xml
+++ b/github-site-plugin/pom.xml
@@ -214,7 +214,7 @@
 		<dependency>
 			<groupId>org.eclipse.mylyn.github</groupId>
 			<artifactId>org.eclipse.egit.github.core</artifactId>
-			<version>2.0.1</version>
+			<version>2.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.github</groupId>


### PR DESCRIPTION
By updating to the latest org.eclipse.egit.github.core, it fixes the following error:

Failed to execute goal com.github.github:downloads-maven-plugin:0.5:upload (default) on project h-ubu: Listing downloads failed: Missing or invalid User Agent string. See http://developer.github.com/v3/#user-agent-required (403) -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.github:downloads-maven-plugin:0.5:upload (default) on project h-ubu: Listing downloads failed: Missing or invalid User Agent string. See http://developer.github.com/v3/#user-agent-required (403)
