### PR TITLE
workaround the case of a non-public email

### DIFF
--- a/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
+++ b/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
@@ -433,7 +433,7 @@ public class SiteMojo extends GitHubProjectMojo {
 
             CommitUser author = new CommitUser();
             author.setName(user.getName());
-            author.setEmail(user.getEmail());
+            author.setEmail(userService.getEmails().get(0));
             author.setDate(new GregorianCalendar().getTime());
 
             commit.setAuthor(author);


### PR DESCRIPTION
As proposed by some others, this works around the issue of not having a public email address on your github profile.

close #69
close #70
close #71
close #73
close #77