### PR TITLE
Fixes 404 getting user email since specific commit

### DIFF
--- a/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
+++ b/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
@@ -433,7 +433,10 @@ public class SiteMojo extends GitHubProjectMojo {
 
             CommitUser author = new CommitUser();
             author.setName(user.getName());
-            author.setEmail(userService.getEmails().get(0));
+            if (user.getEmail() != null)
+                author.setEmail(user.getEmail());
+            else
+                author.setEmail(userService.getEmails().get(0));
             author.setDate(new GregorianCalendar().getTime());
 
             commit.setAuthor(author);

--- a/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
+++ b/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
@@ -433,7 +433,7 @@ public class SiteMojo extends GitHubProjectMojo {
 
             CommitUser author = new CommitUser();
             author.setName(user.getName());
-            if (user.getEmail() != null)
+            if (user.getEmail() != null && !user.getEmail().isEmpty())
                 author.setEmail(user.getEmail());
             else
                 author.setEmail(userService.getEmails().get(0));


### PR DESCRIPTION
Since this commit:

https://github.com/github/maven-plugins/commit/66b1470df954651f9bc81d66c9ffde95cd8e3a53#diff-03ee24f45de9344b334ab56fa56a32f9R436

I'm not able to use the plugin anymore. If I revert exactly that line it works fine.

The error message is:

```
[ERROR] Failed to execute goal com.github.github:site-maven-plugin:0.11:site (default) on project pipes-api: Error retrieving user info: Not Found (404) -> [Help 1]
```

That also doesn't work with the version in the master. 

The error occurs both authenticating via settings.xml and directly in the pom.xml. I'm authenticating to push blobs to a public repository in an organization using my own credentials.
