### PR TITLE
Update version of plugin used in example to 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ prefix of `ghSite`.
     <plugin>
       <groupId>com.github.github</groupId>
       <artifactId>site-maven-plugin</artifactId>
-      <version>0.9</version>
+      <version>0.11</version>
       <configuration>
         <message>Creating site for ${project.version}</message>
       </configuration>


### PR DESCRIPTION
The previous version listed was 0.9, which meant that people copy-pasting straight from the example would likely encounter issue #69.

Signed-off-by: Bob Hogg <hogg.bob.2@gmail.com>