### PR TITLE
Upgrade site-maven-plugin to 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ prefix of `ghSite`.
     <plugin>
       <groupId>com.github.github</groupId>
       <artifactId>site-maven-plugin</artifactId>
-      <version>0.9</version>
+      <version>0.12</version>
       <configuration>
         <message>Creating site for ${project.version}</message>
       </configuration>


### PR DESCRIPTION
Upgrade site-maven-plugin to 0.12 to avoid the "nil" bug causing the `mvn site` to fail. The bug has been fixed but if the dependency is not upgraded, the tutorial won't work.
Once in à.12, it runs fine !