### PR TITLE
Allow user to set calls per minute in the RateLimiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+*.iml
+.idea
 bin
 target

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ by the settings configuration property in parentheses.
   * Name of repository
 * `repositoryOwner`
   * Owner of repository
+* `callsPerMinute` (`github.global.callsPerMinute`)
+  * Number of calls per minute to allow in the rate limiter. Default is 20, which allows 20 calls/min. Setting this to a value like 1000 will allow 1000 calls/minute to github. Useful if you are using GitHub Enterprise or other self hosted solution where the limit isn't capped at a fixed rate like the public GitHub.
 
 *Note:* `repositoryOwner` property and `repositoryName` are optional and will be
 inferred from the following properties if not specified

--- a/github-core/src/main/java/com/github/maven/plugins/core/RateLimitedGitHubClient.java
+++ b/github-core/src/main/java/com/github/maven/plugins/core/RateLimitedGitHubClient.java
@@ -12,18 +12,21 @@ public class RateLimitedGitHubClient extends GitHubClientEgit {
      * AS per https://github.com/octokit/octokit.net/issues/638#issuecomment-67795998,
      * it seems that GitHub only allow 20 API calls per 1-minute period
      */
-    private RateLimiter rateLimiter = RateLimiter.create(20.0/60.0);
+    private RateLimiter rateLimiter;
 
-    public RateLimitedGitHubClient() {
+    public RateLimitedGitHubClient(double callsPerMinute) {
         super();
+        rateLimiter = RateLimiter.create(callsPerMinute/60.0);
     }
 
-    public RateLimitedGitHubClient(String hostname) {
+    public RateLimitedGitHubClient(String hostname, double callsPerMinute) {
         super(hostname);
+        rateLimiter = RateLimiter.create(callsPerMinute/60.0);
     }
 
-    public RateLimitedGitHubClient(String hostname, int port, String scheme) {
+    public RateLimitedGitHubClient(String hostname, int port, String scheme, double callsPerMinute) {
         super(hostname, port, scheme);
+        rateLimiter = RateLimiter.create(callsPerMinute/60.0);
     }
 
     @Override

--- a/github-core/src/test/java/com/github/maven/plugins/core/ClientCredentialsTest.java
+++ b/github-core/src/test/java/com/github/maven/plugins/core/ClientCredentialsTest.java
@@ -56,22 +56,17 @@ public class ClientCredentialsTest {
 
 		private final AtomicReference<String> token = new AtomicReference<String>();
 
-		protected GitHubClient createClient() {
-			try
-			{
-				DefaultPlexusContainer container = new DefaultPlexusContainer();
-				Context context = container.getContext();
-				context.put( PlexusConstants.PLEXUS_KEY, container );
-				super.contextualize(context );
-			}
-			catch ( PlexusContainerException pce )
-			{
-				pce.printStackTrace( System.err );
-			}
-			catch ( ContextException ce )
-			{
-				ce.printStackTrace( System.err );
-			}
+        protected GitHubClient createClient(double callsPerMinute) {
+            try {
+                DefaultPlexusContainer container = new DefaultPlexusContainer();
+                Context context = container.getContext();
+                context.put(PlexusConstants.PLEXUS_KEY, container);
+                super.contextualize(context);
+            } catch (PlexusContainerException pce) {
+                pce.printStackTrace(System.err);
+            } catch (ContextException ce) {
+                ce.printStackTrace(System.err);
+            }
 
 			return new GitHubClient() {
 				public GitHubClient setCredentials(String user, String password) {
@@ -85,17 +80,29 @@ public class ClientCredentialsTest {
 					return super.setOAuth2Token(token);
 				}
 
-			};
-		}
+            };
+        }
 
-		@Override
-		public GitHubClient createClient(String host, String userName,
-				String password, String oauth2Token, String serverId,
-				Settings settings, MavenSession session)
-				throws MojoExecutionException {
-			return super.createClient(host, userName, password, oauth2Token,
-					serverId, settings, session);
-		}
+        protected GitHubClient createClient() {
+            return createClient(20.0);
+        }
+
+        public GitHubClient createClient(String host, String userName,
+                                         String password, String oauth2Token, String serverId,
+                                         Settings settings, MavenSession session, double callsPerMinute)
+                throws MojoExecutionException {
+            return super.createClient(host, userName, password, oauth2Token,
+                    serverId, settings, session, callsPerMinute);
+        }
+
+        @Override
+        public GitHubClient createClient(String host, String userName,
+                                         String password, String oauth2Token, String serverId,
+                                         Settings settings, MavenSession session)
+                throws MojoExecutionException {
+            return this.createClient(host, userName, password, oauth2Token,
+                    serverId, settings, session, 20.0);
+        }
 
 		public void execute() throws MojoExecutionException,
 				MojoFailureException {

--- a/github-core/src/test/java/com/github/maven/plugins/core/CustomHostnameTest.java
+++ b/github-core/src/test/java/com/github/maven/plugins/core/CustomHostnameTest.java
@@ -45,23 +45,22 @@ public class CustomHostnameTest {
 
 		private final AtomicReference<String> host = new AtomicReference<String>();
 
-		protected GitHubClient createClient() {
+		protected GitHubClient createClient(double callsPerMinute) {
 			host.set(null);
-			return super.createClient();
+			return super.createClient(20.0);
 		}
 
-		protected GitHubClient createClient(String hostname)
-				throws MojoExecutionException {
+		protected GitHubClient createClient(String hostname, double callsPerMinute) throws MojoExecutionException {
 			host.set(hostname);
-			return super.createClient(hostname);
+			return super.createClient(hostname, callsPerMinute);
 		}
 
 		public GitHubClient createClient(String host, String userName,
 				String password, String oauth2Token, String serverId,
-				Settings settings, MavenSession session)
+				Settings settings, MavenSession session, double callsPerMinute)
 				throws MojoExecutionException {
 			return super.createClient(host, userName, password, oauth2Token,
-					serverId, settings, session);
+					serverId, settings, session, callsPerMinute);
 		}
 
 		public void execute() throws MojoExecutionException,

--- a/github-site-plugin/pom.xml
+++ b/github-site-plugin/pom.xml
@@ -14,7 +14,7 @@
     <description>Maven plugin that commits files to a branch in a GitHub repository</description>
 
     <properties>
-        <last.released.version>0.9</last.released.version>
+        <last.released.version>0.12</last.released.version>
     </properties>
 
     <build>

--- a/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
+++ b/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
@@ -244,9 +244,10 @@ public class SiteMojo extends GitHubProjectMojo {
     private boolean skip;
 
     /**
-     * The number of calls per minute to allow to github. Default to 20/min
+     * The number of calls per minute to allow to github. Default to 20.
      *
      * @parameter expression="${github.site.callsPerMinute}"
+	 *            default-value="20.0"
      */
     private double callsPerMinute;
 

--- a/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
+++ b/github-site-plugin/src/main/java/com/github/maven/plugins/site/SiteMojo.java
@@ -243,6 +243,13 @@ public class SiteMojo extends GitHubProjectMojo {
      */
     private boolean skip;
 
+    /**
+     * The number of calls per minute to allow to github. Default to 20/min
+     *
+     * @parameter expression="${github.site.callsPerMinute}"
+     */
+    private double callsPerMinute;
+
 	/**
 	 * Create blob
 	 *
@@ -328,7 +335,7 @@ public class SiteMojo extends GitHubProjectMojo {
 					Arrays.toString(paths)));
 
 		DataService service = new DataService(createClient(host, userName,
-				password, oauth2Token, server, settings, session));
+				password, oauth2Token, server, settings, session, callsPerMinute));
 
 		// Write blobs and build tree entries
 		List<TreeEntry> entries = new ArrayList<TreeEntry>(paths.length);


### PR DESCRIPTION
Allow user to provide a param `callsPerMinute` via configuration block to allow more calls per minute to github.  Without param default is 20.  This will address some issues from #90 #17 #28 #88  @jakeswenson @alem0lars @bguerin @kevinsawicki 

User can configure the following
```xml
            <plugin>
                <groupId>com.github.github</groupId>
                <artifactId>site-maven-plugin</artifactId>
                <version>0.13-SNAPSHOT</version>
                <configuration>
                    <callsPerMinute>1000</callsPerMinute>
                </configuration>
            </plugin>
```